### PR TITLE
Add support for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+
+updates:
+    -   package-ecosystem: "github-actions"
+        directory: "/"
+        schedule:
+            interval: daily
+    -   package-ecosystem: "gomod"
+        directory: "/"
+        schedule:
+            interval: "daily"


### PR DESCRIPTION
I noticed that some of the dependencies in the go.mod are outdated. This PR adds support for dependabot to track dependencies.